### PR TITLE
Correct Cyclops/Phoenix pack designation

### DIFF
--- a/src/data/heroes.js
+++ b/src/data/heroes.js
@@ -265,13 +265,13 @@ export const heroes = [
         heroImg: 'images/heroes/mc33_cyclops.png',
         alterEgo: 'Scott Summers',
         alterEgoImg: 'images/heroes/mc33_scott_summers.png',
-        pack: 'Mutant Genesis',
+        pack: 'Cyclops',
     },
     {
         hero: 'Phoenix',
         heroImg: 'images/heroes/mc34_phoenix.png',
         alterEgo: 'Jean Grey',
         alterEgoImg: 'images/heroes/mc34_jean_grey.png',
-        pack: 'Mutant Genesis',
+        pack: 'Phoenix',
     },
 ];


### PR DESCRIPTION
Corrected Cyclops and Phoenix pack designation from "Mutant Genesis" to their own hero packs.