### PR TITLE
minor styling updates for mobile and added engines block to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "browserslist": [
     "> 1%",
     "last 2 versions"
-  ]
+  ],
+  "engines": {
+    "node": ">=12.0.0"
+  }
 }

--- a/src/components/ChangeLog.vue
+++ b/src/components/ChangeLog.vue
@@ -4,6 +4,12 @@
 
         <div v-if="shown">
             <div class="changelog-entry">
+              <h3>On december 5th 2022</h3>
+              <ul>
+                <li>Minor design updates for mobile</li>
+              </ul>
+            </div>
+            <div class="changelog-entry">
               <h3>On november 21st 2022</h3>
               <ul>
                 <li>Add Magneto ally card requirement for Master Mold scenario</li>

--- a/src/components/EncounterDeck.vue
+++ b/src/components/EncounterDeck.vue
@@ -38,6 +38,9 @@ export default {
 
 img{
   max-width: 480px;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 10px;
 }
 
 .module-title{

--- a/src/components/ScenarioDisplay.vue
+++ b/src/components/ScenarioDisplay.vue
@@ -77,6 +77,7 @@ img {
 
 .content {
   text-align: center;
+  padding-top: 5px;
 }
 
 .toggle {


### PR DESCRIPTION
Summary of changes:

- added engines block to package.json with node version
  - targeted Node v12 since that is the version used by the GitHub workflow
- added some minor styling updates to the scenario component
- added some minor styling updates to the  encounter deck display to prevent overflow on mobile

Details:

I added some minor styling changes in order to help prevent the encounter deck images from overflowing the parent container when viewing on a mobile or smaller screen. Example:
<img width="462" alt="Screen Shot 2022-12-05 at 11 11 28 AM" src="https://user-images.githubusercontent.com/9931822/205690384-2c96c60f-b559-4ad7-98af-673548edebbe.png">

I also added some small padding between the `Scenario` title and the scenario image so they two elements would have some spacing. Example:
<img width="417" alt="Screen Shot 2022-12-05 at 11 11 36 AM" src="https://user-images.githubusercontent.com/9931822/205690613-d7c7668f-0b77-4865-8dfa-f006b5a24fb5.png">
