### PR TITLE
Adds the ability to select a star difficulty ranking to limit scenario and module selection.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,7 @@ import {scenarios} from './data/scenarios';
 import {modules} from './data/modules';
 import {heroes} from './data/heroes';
 import {aspects} from "@/data/aspects";
+import { starRatingDifficultyRange } from "@/data/starRatingDifficultyRange.js";
 import PlayerSelector from "@/components/PlayerSelector";
 import RandomizationOptions from "@/components/RandomizationOptions";
 import PackSelector from "@/components/PackSelector";
@@ -76,6 +77,21 @@ try {
   dataStorage.removeItem("selectedDifficulties");
 }
 
+let selectedStarRating = null;
+try {
+  selectedStarRating = JSON.parse(dataStorage.getItem("selectedStarRating")) || {
+      useStarRating: false,
+      starRating: 2,
+      starRatingRange: starRatingDifficultyRange[2]
+    };
+} catch {
+  selectedStarRating = {
+      useStarRating: false,
+      starRating: 2,
+      starRatingRange: starRatingDifficultyRange[2]
+    };
+  dataStorage.removeItem("selectedStarRating");
+}
 
 export default {
   name: 'app',
@@ -97,6 +113,7 @@ export default {
       decks: 1,
       selectedDifficulties,
       limitToScenarios: [],
+      ...selectedStarRating
     },
     appStatus: {updated: false},
   }),
@@ -108,6 +125,8 @@ export default {
     randomizationOptions: {
       handler() {
         dataStorage.setItem("selectedDifficulties", JSON.stringify(this.randomizationOptions.selectedDifficulties));
+        const {useStarRating, starRating, starRatingRange } = this.randomizationOptions;
+        dataStorage.setItem("selectedStarRating", JSON.stringify({useStarRating, starRating, starRatingRange}));
         this.randomize();
       },
       deep: true,

--- a/src/components/RandomizationOptions.vue
+++ b/src/components/RandomizationOptions.vue
@@ -6,7 +6,7 @@
     <div v-if="shown">
       <div>
         <button :disabled="modelValue.additionalModules <= 0"
-                @click="additionalModulesChange((modelValue.additionalModules || 0) - 1)">-
+          @click="additionalModulesChange((modelValue.additionalModules || 0) - 1)">-
         </button>
         {{ modelValue.additionalModules || 0 }}
         <button @click="additionalModulesChange(parseInt(modelValue.additionalModules || 0) + 1)">+</button>
@@ -25,6 +25,27 @@
           Generate Player Decks
         </label>
       </div>
+      <br />
+      <div>
+        <label>
+          <input type="checkbox" name="scenario" id="decks" :checked="modelValue.useStarRating"
+            @input="toggleStarRating">
+          Use Starred Difficulty Level (see the <a target="_blank" rel="noopener noreferrer" href="https://boardgamegeek.com/thread/2438111/star-difficulty-levels/page/1">BGG page</a> for more details)
+        </label>
+      </div>
+      <div v-if="modelValue.useStarRating" class="star-rating">
+        <div :key="rating" v-for="rating in [0, 1, 2, 3, 4, 5]">
+          <button v-if="rating == 0" :style="{ backgroundColor: modelValue.starRating != rating ? 'white' : 'yellow' }"
+            :alt="rating" @click="setStarRating(rating)">
+            {{ rating == 0 ? "0 Stars" : "" }}
+          </button>
+          <button v-if="rating > 0" class="star" :style="{ backgroundColor: modelValue.starRating < rating ? 'black' : 'yellow' }"
+            :alt="rating" @click="setStarRating(rating)">
+            {{ rating == 0 ? "0 Stars" : "" }}
+          </button>
+        </div>
+      </div>
+
 
       <div @click="shown=!shown" class="panel-insert-content">
         Hide Options
@@ -40,6 +61,8 @@
 </template>
 
 <script>
+import { starRatingDifficultyRange } from "@/data/starRatingDifficultyRange.js";
+
 export default {
   name: "RandomizationOptions",
   props: {
@@ -67,11 +90,33 @@ export default {
         ...this.modelValue,
         decks: !this.modelValue.decks
       });
+    },
+    toggleStarRating() {
+      this.$emit("update:modelValue", {
+        ...this.modelValue,
+        useStarRating: !this.modelValue.useStarRating
+      });
+    },
+    setStarRating(starRatingOption) {
+      this.$emit("update:modelValue", {
+        ...this.modelValue,
+        starRating: starRatingOption,
+        starRatingRange: starRatingDifficultyRange[starRatingOption],
+      });
     }
   },
 }
 </script>
 
 <style scoped>
+.star-rating {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
 
+.star {
+  aspect-ratio: 1;
+  clip-path: polygon(50% 0,79% 90%,2% 35%,98% 35%,21% 90%); 
+}
 </style>

--- a/src/components/ScenarioDisplay.vue
+++ b/src/components/ScenarioDisplay.vue
@@ -3,6 +3,11 @@
     <div class="title panel-insert" @click="shown=!shown">Scenario</div>
     <div class="content" v-if="shown">
       <div>
+        <div v-if="scenario.useStarRating" class="difficulty panel-insert-content">
+          Star Rating Difficulty: 
+          <span class="difficulty-value">{{ scenario.starRatingDifficulty }}</span>
+        </div>
+
         <div class="main-scenario">
           <img :src="scenario.scenario.img" :alt="scenario.scenario.name">
           <div class="panel-insert-content scenario-title">

--- a/src/data/modules.js
+++ b/src/data/modules.js
@@ -3,565 +3,675 @@ export const modules = [
         name: "Bomb Scare",
         img: 'images/modules/MC01en_109.jpg',
         pack: "Core Set",
+        starRating: -2
     },
     {
         name: "The Masters of Evil",
         img: 'images/modules/MC01en_128.jpg',
         pack: "Core Set",
+        starRating: 1
     },
     {
         name: "Under Attack",
         img: 'images/modules/MC01en_151.jpg',
         pack: "Core Set",
+        starRating: 1
     },
     {
         name: "The Legions of Hydra",
         img: 'images/modules/MC01en_180.jpg',
         pack: "Core Set",
+        starRating: 4
     },
     {
         name: "The Doomsday Chair",
         img: 'images/modules/MC01en_183.jpg',
         pack: "Core Set",
+        starRating: 4
     },
     {
         name: "Goblin Gimmicks",
         img: "images/modules/mc02en_card_goblin-glider.jpg",
-        pack: "Green Goblin"
+        pack: "Green Goblin",
+        starRating: -3
     },
     {
         name: "A Mess of Things",
         img: "images/modules/02037.jpg",
-        pack: "Green Goblin"
+        pack: "Green Goblin",
+        starRating: 1
     },
     {
         name: "Power Drain",
         img: "images/modules/02041.jpg",
-        pack: "Green Goblin"
+        pack: "Green Goblin",
+        starRating: -2
     },
     {
         name: "Running Interference",
         img: "images/modules/02046.jpg",
-        pack: "Green Goblin"
+        pack: "Green Goblin",
+        starRating: -1
     },
     {
         name: "Weapon Master",
         img: "images/modules/MC10en_148.jpg",
         pack: "The Rise of Red Skull",
+        starRating: 1
     },
     {
         name: "Experimental Weapons",
         img: "images/modules/MC10en_72.jpg",
         pack: "The Rise of Red Skull",
+        starRating: -2
     },
     {
         name: "Hydra Assault",
         img: "images/modules/MC10en_145.jpg",
         pack: "The Rise of Red Skull",
+        starRating: -3
     },
     {
         name: "Hydra Patrol",
         img: "images/modules/MC10en_152.jpg",
         pack: "The Rise of Red Skull",
+        starRating: 0
     },
     {
         name: "Anachronauts",
         img: "images/modules/MC11en_40.jpg",
         pack: "The Once and Future Kang",
+        starRating: 1
     },
     {
         name: "Master of Time",
         img: "images/modules/MC11en_47.jpg",
         pack: "The Once and Future Kang",
+        starRating: 1
     },
     {
         name: "Temporal",
         img: "images/modules/MC11en_30.jpg",
         pack: "The Once and Future Kang",
+        starRating: -2,
     },
     {
         name: "Kree Fanatic",
         img: "images/modules/gen_con_2020_ronan.jpg",
         pack: "Ronan the Accuser (Print and Play)",
+        starRating: 7
     },
     {
         name: "Band of Badoon",
         img: "images/modules/MC16en_117.jpg",
         pack: "Galaxy's Most Wanted",
+        starRating: -1
     },
     {
         name: "Galactic Artifacts",
         img: "images/modules/MC16en_122.jpg",
         pack: "Galaxy's Most Wanted",
+        starRating: 0
     },
     {
         name: "Kree Militants",
         img: "images/modules/MC16en_131.jpg",
         pack: "Galaxy's Most Wanted",
+        starRating: -3
     },
     {
         name: "Menagerie Medley",
         img: "images/modules/MC16en_135.jpg",
         pack: "Galaxy's Most Wanted",
+        starRating: 1
     },
     {
         name: "Space Pirates",
         img: "images/modules/MC16en_138.jpg",
         pack: "Galaxy's Most Wanted",
+        starRating: -1
     },
     {
         name: "Power Stone",
         img: "images/modules/power-stone.jpg",
         pack: "Galaxy's Most Wanted",
         randomize: false,
+        starRating: 0
     },
     {
         name: "Ship Command",
         img: "images/modules/ship-command.png",
         pack: "Galaxy's Most Wanted",
         randomize: false,
+        starRating: -2
     },
     {
         name: "The Black Order",
         img: "images/modules/MC21en_85.jpg",
         pack: "The Mad Titan's Shadow",
+        starRating: -1
     },
     {
         name: "Armies of Titan",
         img: "images/modules/MC21en_89.jpg",
         pack: "The Mad Titan's Shadow",
+        starRating: -1
     },
     {
         name: "Children of Thanos",
         img: "images/modules/MC21en_125.jpg",
         pack: "The Mad Titan's Shadow",
+        starRating: 0
     },
     {
         name: "Infinity Gauntlet",
         img: "images/modules/MC21en_129.jpg",
         pack: "The Mad Titan's Shadow",
+        starRating: 7
     },
     {
         name: "Legions of Hel",
         img: "images/modules/MC21en_152.jpg",
         pack: "The Mad Titan's Shadow",
+        starRating: -1
     },
     {
         name: "Frost Giants",
         img: "images/modules/MC21en_156.jpg",
         pack: "The Mad Titan's Shadow",
+        starRating: 1
     },
     {
         name: "Enchantress",
         img: "images/modules/MC21en_177.jpg",
         pack: "The Mad Titan's Shadow",
+        starRating: 3
     },
     {
         name: "Beasty Boys",
         img: "images/modules/MC24en_14.jpg",
         pack: "The Hood",
+        starRating: -1
     },
     {
         name: "Brothers Grimm",
         img: "images/modules/MC24en_18.jpg",
         pack: "The Hood",
+        starRating: 0
     },
     {
         name: "Crossfire's Crew",
         img: "images/modules/MC24en_23.jpg",
         pack: "The Hood",
+        starRating: 2
     },
     {
         name: "Mister Hyde",
         img: "images/modules/MC24en_33.png",
         pack: "The Hood",
+        starRating: 2
     },
     {
         name: "Ransacked Armory",
         img: "images/modules/MC24en_37.png",
         pack: "The Hood",
+        starRating: -1
     },
     {
         name: "Sinister Syndicate",
         img: "images/modules/MC24en_42.jpg",
         pack: "The Hood",
+        starRating: 1
     },
     {
         name: "State of Emergency",
         img: "images/modules/MC24en_55.jpg",
         pack: "The Hood",
+        starRating: 2
     },
     {
         name: "Streets of Mayhem",
         img: "images/modules/MC24en_60.jpg",
         pack: "The Hood",
+        starRating: 1
     },
     {
         name: "Wrecking Crew",
         img: "images/modules/MC24en_64.jpg",
         pack: "The Hood",
+        starRating: 2
     },
     {
         name: "City in Chaos",
         img: "images/modules/city-in-chaos.png",
         pack: "Sinister Motives",
+        starRating: 3
     },
     {
         name: "Down to Earth",
         img: "images/modules/down-to-earth.png",
         pack: "Sinister Motives",
+        starRating: -1
     },
     {
         name: "Goblin Gear",
         img: "images/modules/goblin-gear.png",
         pack: "Sinister Motives",
+        starRating: 2
     },
     {
         name: "Guerrilla Tactics",
         img: "images/modules/guerrilla-tactics.png",
         pack: "Sinister Motives",
+        starRating: 2
     },
     {
         name: "Osborn Tech",
         img: "images/modules/osborn-tech.png",
         pack: "Sinister Motives",
+        starRating: 2
     },
     {
         name: "Personal Nightmare",
         img: "images/modules/personal-nightmare.png",
         pack: "Sinister Motives",
+        starRating: 1
     },
     {
         name: "Sinister Assault",
         img: "images/modules/sinister-assault.png",
         pack: "Sinister Motives",
+        starRating: 1
     },
     {
         name: "Symbiotic Strength",
         img: "images/modules/symbiotic-strength.png",
         pack: "Sinister Motives",
+        starRating: 3
     },
     {
         name: "Whispers of Paranoia",
         img: "images/modules/whispers-of-paranoia.png",
         pack: "Sinister Motives",
+        starRating: 1
     },
     {
         name: "Armadillo",
         img: "images/modules/mc28_nova_cardsingles__armadillo.png",
         pack: "Nova",
+        starRating: -3
     },
     {
         name: "Zzzax",
         img: "images/modules/mc29en_feedback_loop_36.png",
         pack: "Ironheart",
+        starRating: 1
     },
     {
         name: "The Inheritors",
         img: "images/modules/mc30_spider-ham_cardsingles__bora.png",
         pack: "Spider-Ham",
+        starRating: 3
     },
     {
         name: "Iron Spider's Sinister Six",
         img: "images/modules/mc31_spdr_isss.png",
         pack: "SP//dr",
+        starRating: 3
     },
     {
         name: "Acolytes",
         img: "images/modules/mc32_acolytes.png",
         pack: "Mutant Genesis",
+        starRating: -2
     },
     {
         name: "Brotherhood",
         img: "images/modules/mc32_brotherhood.png",
         pack: "Mutant Genesis",
+        starRating: 4
     },
     {
         name: "Future Past",
         img: "images/modules/mc32_future_past.png",
         pack: "Mutant Genesis",
+        starRating: 3
     },
     {
         name: "Mystique",
         img: "images/modules/mc32_mystique.png",
         pack: "Mutant Genesis",
+        starRating: 3
     },
     {
         name: "Sentinels",
         img: "images/modules/mc32_sentinels.png",
         pack: "Mutant Genesis",
+        starRating: 3
     },
     {
         name: "Zero Tolerance",
         img: "images/modules/mc32_zero_tolerance.png",
         pack: "Mutant Genesis",
+        starRating: -2
     },
     {
         name: "Magneto (campaign cards)",
         img: "images/scenarios/magneto-ally.png",
         pack: "Mutant Genesis",
         randomize: false,
+        starRating: 0
     },
     {
         name: "Deathstrike",
         img: "images/modules/mc35_deathstrike.png",
         pack: "Wolverine",
+        starRating: 5
     },
     {
         name: "Shadow King",
         img: "images/modules/mc36_shadow_king.png",
         pack: "Storm",
+        starRating: 2
     },
     {
         name: "Crime",
         img: "images/modules/mc39_crime.png",
         pack: "MojoMania",
+        starRating: 0
     },
     {
         name: "Fantasy",
         img: "images/modules/mc39_fantasy.png",
         pack: "MojoMania",
+        starRating: -3
     },
     {
         name: "Horror",
         img: "images/modules/mc39_horror.png",
         pack: "MojoMania",
+        starRating: 1
     },
     {
         name: "Sci-Fi",
         img: "images/modules/mc39_scifi.png",
         pack: "MojoMania",
+        starRating: 3
     },
     {
         name: "Sitcom",
         img: "images/modules/mc39_sitcom.png",
         pack: "MojoMania",
+        starRating: 3
     },
     {
         name: "Western",
         img: "images/modules/mc39_western.png",
         pack: "MojoMania",
+        starRating: -2
     },
     {
         name: "Exodus",
         img: "images/modules/exodus.jpg",
         pack: "Gambit",
+        starRating: 5
     },
     {
         name: "Reavers",
         img: "images/modules/reavers.jpg",
         pack: "Rogue",
+        starRating: 6
     },
     {
         name: "Black Tom Cassidy",
         img: "images/modules/black-tom-cassidy.jpg",
         pack: "NeXt Evolution",
+        starRating: 3
     },
     {
         name: "Extreme Measures",
         img: "images/modules/extreme-measures.jpg",
         pack: "NeXt Evolution",
+        starRating: 4
     },
     {
         name: "Flight",
         img: "images/modules/flight.jpg",
         pack: "NeXt Evolution",
+        starRating: 1
     },
     {
         name: "Hope Summers",
         img: "images/modules/hope-summers.jpg",
         pack: "NeXt Evolution",
         randomize: false,
+        starRating: -4
     },
     {
         name: "Marauders",
         img: "images/modules/marauders.jpg",
         pack: "NeXt Evolution",
         randomize: false,
+        starRating: 0
     },
     {
         name: "Military Grade",
         img: "images/modules/military-grade.jpg",
         pack: "NeXt Evolution",
+        starRating: 1
     },
     {
         name: "Mutant Insurrection",
         img: "images/modules/mutant-insurrection.jpg",
         pack: "NeXt Evolution",
+        starRating: 1
     },
     {
         name: "Mutant Slayers",
         img: "images/modules/mutant-slayers.jpg",
         pack: "NeXt Evolution",
+        starRating: -2
     },
     {
         name: "Nasty Boys",
         img: "images/modules/nasty-boys.jpg",
         pack: "NeXt Evolution",
+        starRating: 3
     },
     {
         name: "Super Strength",
         img: "images/modules/super-strength.jpg",
         pack: "NeXt Evolution",
+        starRating: -3
     },
     {
         name: "Telepathy",
         img: "images/modules/telepathy.jpg",
         pack: "NeXt Evolution",
+        starRating: 0
     },
     {
         name: "Infinites",
         img: "images/modules/mc45_unus_cards_infinitesoldier.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 6
     },
     {
         name: "Dystopian Nightmare",
         img: "images/modules/dystopian-nightmare.jpg",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 0
     },
     {
         name: "Hounds",
         img: "images/modules/mc45_fourhorsemen_cards_ahab.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 0
     },
     {
         name: "Prelates",
         img: "images/modules/mc45_apocalypse_cards_mistersinister.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 0
     },
     {
         name: "Dark Riders",
         img: "images/modules/mc45_apocalypse_cards_gauntlet.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 0
     },
     {
         name: "Savage Land",
         img: "images/modules/mc45_darkbeast_cards_thesavageland.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: -2
     },
     {
         name: "Genosha",
         img: "images/modules/mc45_darkbeast_cards_genosha.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 1
     },
     {
         name: "Blue Moon",
         img: "images/modules/mc45_darkbeast_cards_blueareaofthemoon.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: -1
     },
     {
         name: "Celestial Tech",
         img: "images/modules/mc45_ensabahnur_cards_celestialarmor.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 0
     },
     {
         name: "Clan Akkaba",
         img: "images/modules/mc45_ensabahnur_cards_ozymandias.png",
-        pack: "Age of Apocalypse"
+        pack: "Age of Apocalypse",
+        starRating: 1
     },
     {
         name: "Sauron",
         img: "images/modules/mc46_announce_cards_sauron.png",
-        pack: "Iceman"
+        pack: "Iceman",
+        starRating: 6
     },
     {
         name: "Arcade",
         img: "images/modules/mc47_announce_cards_arcade.png",
-        pack: "Jubilee"
+        pack: "Jubilee",
+        starRating: -1
     },
     {
         name: "Crazy Gang",
         img: "images/modules/mc48_announcement_article_the_crazy_gang_33_card_horizontal.png",
-        pack: "Nightcrawler"
+        pack: "Nightcrawler",
+        starRating: -8
     },
     {
         name: "Hellfire",
         img: "images/modules/mc49_announce_cards_sebastianshaw.png",
-        pack: "Magneto"
+        pack: "Magneto",
+        starRating: -2
     },
     {
         name: "A.I.M. Abduction",
         img: "images/modules/aim-abduction.jpg",
-        pack: "Agents of S.H.I.E.L.D."
+        pack: "Agents of S.H.I.E.L.D.",
+        starRating: 4
     },
     {
         name: "A.I.M. Science",
         img: "images/modules/aim-science.jpg",
-        pack: "Agents of S.H.I.E.L.D."
+        pack: "Agents of S.H.I.E.L.D.",
+        starRating: 0
     },
     {
         name: "Batroc's Brigade",
         img: "images/modules/batrocs-brigade.jpg",
-        pack: "Agents of S.H.I.E.L.D."
+        pack: "Agents of S.H.I.E.L.D.",
+        starRating: -12
     },
     {
         name: "Scientist Supreme",
         img: "images/modules/scientist-supreme.jpg",
-        pack: "Agents of S.H.I.E.L.D."
+        pack: "Agents of S.H.I.E.L.D.",
+        starRating: 3
     },
     {
         name: "Gravitational Pull",
         img: "images/modules/gravitational-pull.jpg",
         pack: "Agents of S.H.I.E.L.D.",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: 6
     },
     {
         name: "Hard Sound",
         img: "images/modules/hard-sound.jpg",
         pack: "Agents of S.H.I.E.L.D.",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: 10
     },
     {
         name: "Pale Little Spider",
         img: "images/modules/pale-little-spider.jpg",
         pack: "Agents of S.H.I.E.L.D.",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: 1
     },
     {
         name: "Power of the Atom",
         img: "images/modules/power-of-the-atom.jpg",
         pack: "Agents of S.H.I.E.L.D.",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: -12
     },
     {
         name: "Supersonic",
         img: "images/modules/supersonic.jpg",
         pack: "Agents of S.H.I.E.L.D.",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: 9
     },
     {
         name: "The Leaper",
         img: "images/modules/the-leaper.jpg",
         pack: "Agents of S.H.I.E.L.D.",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: -5
     },
     {
         name: "S.H.I.E.L.D.",
         img: "images/modules/shield.jpg",
-        pack: "Agents of S.H.I.E.L.D."
+        pack: "Agents of S.H.I.E.L.D.",
+        starRating: -3
     },
     {
         name: "S.H.I.E.L.D. Executive Board",
         img: "images/modules/shield-executive-board.jpg",
         pack: "Agents of S.H.I.E.L.D.",
         randomize: false,
+        starRating: 0
     },
     {
         name: "Executive Board Evidence",
         img: "images/modules/executive-evidence-board.jpg",
         pack: "Agents of S.H.I.E.L.D.",
         randomize: false,
+        starRating: 0
     },
     {
         name: "Extreme Risk",
         img: "images/modules/mc51_announce_cards_joystick.png",
         pack: "Black Panther",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: 0
     },
     {
         name: "Growing Strong",
         img: "images/modules/mc52_announcement_article_atlas_35.png",
         pack: "Silk",
-        types: ["Thunderbolt"]
+        types: ["Thunderbolt"],
+        starRating: 0
     }
 ];

--- a/src/data/scenarios.js
+++ b/src/data/scenarios.js
@@ -3,31 +3,55 @@ export const scenarios = [
         name: 'Rhino - The Break In!',
         img: 'images/scenarios/MC01en_97A.jpg',
         pack: "Core Set",
+        starRating: {
+            solo: 7,
+            multiplayer: 0
+        }
     },
     {
         name: 'Klaw - Underground Distribution',
         img: 'images/scenarios/MC01en_116A.jpg',
         pack: "Core Set",
+        starRating: {
+            solo: 10,
+            multiplayer: 3
+        }
     },
     {
         name: 'Ultron - The Crimson Cowl',
         img: 'images/scenarios/MC01en_137A.jpg',
         pack: "Core Set",
+        starRating: {
+            solo: 10,
+            multiplayer: 12
+        }
     },
     {
         name: 'Green Goblin - Risky Business',
         img: 'images/scenarios/02004.jpg',
         pack: "Green Goblin",
+        starRating: {
+            solo: 0,
+            multiplayer: 0
+        }
     },
     {
         name: 'Green Goblin - Mutagen Formula',
         img: 'images/scenarios/02017.jpg',
         pack: 'Green Goblin',
+        starRating: {
+            solo: 12,
+            multiplayer: 10
+        },
     },
     {
         name: 'Wrecking Crew - Breakout',
         img: 'images/scenarios/MC03en_1A.jpg',
         pack: 'Wrecking Crew',
+        starRating: {
+            solo: -1,
+            multiplayer: 3
+        },
         decks: [
             {
                 name: "Bulldozer's Deck",
@@ -70,6 +94,10 @@ export const scenarios = [
         name: "Crossbones - Attack on Mount Athena",
         pack: "The Rise of Red Skull",
         img: "images/scenarios/MC10en_61A.jpg",
+        starRating: {
+            solo: 4,
+            multiplayer: -1
+        },
         decks: [
             {
                 requiredModules: ["Experimental Weapons"],
@@ -80,12 +108,20 @@ export const scenarios = [
     {
         name: "Absorbing Man - None Shall Pass",
         pack: "The Rise of Red Skull",
-        img: "images/scenarios/MC10en_79A.jpg"
+        img: "images/scenarios/MC10en_79A.jpg",
+        starRating: {
+            solo: 2,
+            multiplayer: -1
+        },
     },
     {
         name: "Taskmaster - Hunting Down Heroes",
         pack: "The Rise of Red Skull",
         img: "images/scenarios/MC10en_96A.jpg",
+        starRating: {
+            solo: 5,
+            multiplayer: 5
+        },
         decks: [
             {
                 requiredModules: ["Hydra Patrol"],
@@ -96,11 +132,19 @@ export const scenarios = [
         name: "Zola - The Island of Dr. Zola",
         pack: "The Rise of Red Skull",
         img: "images/scenarios/MC10en_112A.jpg",
+        starRating: {
+            solo: 14,
+            multiplayer: 9
+        },
     },
     {
         name: "Red Skull - The Rise of Red Skull",
         pack: "The Rise of Red Skull",
         img: "images/scenarios/MC10en_128A.jpg",
+        starRating: {
+            solo: 16,
+            multiplayer: 17
+        },
         decks: [
             {
                 minModules: 2,
@@ -111,11 +155,19 @@ export const scenarios = [
         name: "Kang - Kang's Arrival",
         pack: "The Once and Future Kang",
         img: "images/scenarios/MC11en_7A.jpg",
+        starRating: {
+            solo: 10,
+            multiplayer: 9
+        },
     },
     {
         name: "Brotherhood of Badoon",
         pack: "Galaxy's Most Wanted",
         img: "images/scenarios/MC16en_61A.jpg",
+        starRating: {
+            solo: 2,
+            multiplayer: 7
+        },
         decks: [
             {
                 requiredModules: ["Brotherhood of Badoon", "Ship Command"],
@@ -127,6 +179,10 @@ export const scenarios = [
         name: "Collector 1 - Infiltrate the Museum",
         pack: "Galaxy's Most Wanted",
         img: "images/scenarios/MC16en_73A.jpg",
+        starRating: {
+            solo: 14,
+            multiplayer: 11
+        },
         decks: [
             {
                 requiredModules: ["Galactic Artifacts"],
@@ -137,6 +193,10 @@ export const scenarios = [
         name: "Collector 2 - Escape the Museum",
         pack: "Galaxy's Most Wanted",
         img: "images/scenarios/MC16en_82A.jpg",
+        starRating: {
+            solo: 12,
+            multiplayer: 11
+        },
         decks: [
             {
                 requiredModules: ["Galactic Artifacts", "Ship Command"],
@@ -147,6 +207,10 @@ export const scenarios = [
         name: "Nebula",
         pack: "Galaxy's Most Wanted",
         img: "images/scenarios/MC16en_91A.jpg",
+        starRating: {
+            solo: 17,
+            multiplayer: 19
+        },
         decks: [
             {
                 requiredModules: ["Power Stone", "Ship Command"],
@@ -157,6 +221,10 @@ export const scenarios = [
         name: "Ronan",
         pack: "Galaxy's Most Wanted",
         img: "images/scenarios/MC16en_106A.jpg",
+        starRating: {
+            solo: 24,
+            multiplayer: 25
+        },
         decks: [
             {
                 requiredModules: ["Power Stone", "Ship Command"],
@@ -167,6 +235,10 @@ export const scenarios = [
         name: "Ebony Maw - Attack on Knowhere",
         pack: "The Mad Titan's Shadow",
         img: "images/scenarios/MC21en_74A.jpg",
+        starRating: {
+            solo: 6,
+            multiplayer: 5
+        },
         decks: [
             {
                 minModules: 2,
@@ -177,11 +249,19 @@ export const scenarios = [
         name: "Proxima Midnight/Corvus Glaive - Under Siege",
         pack: "The Mad Titan's Shadow",
         img: "images/scenarios/MC21en_98A.jpg",
+        starRating: {
+            solo: -1,
+            multiplayer: 0
+        },
     },
     {
         name: "Thanos - The Infinity Stones",
         pack: "The Mad Titan's Shadow",
         img: "images/scenarios/MC21en_114A.jpg",
+        starRating: {
+            solo: 8,
+            multiplayer: 8
+        },
         decks: [
             {
                 requiredModules: ["Infinity Gauntlet"],
@@ -193,6 +273,10 @@ export const scenarios = [
         name: "Hela - Odin's Torment",
         pack: "The Mad Titan's Shadow",
         img: "images/scenarios/MC21en_138A.jpg",
+        starRating: {
+            solo: 10,
+            multiplayer: 6
+        },
         decks: [
             {
                 minModules: 2,
@@ -203,6 +287,10 @@ export const scenarios = [
         name: "Loki - All Hail King Loki",
         pack: "The Mad Titan's Shadow",
         img: "images/scenarios/MC21en_165A.jpg",
+        starRating: {
+            solo: 18,
+            multiplayer: 19
+        },
         decks: [
             {
                 requiredModules: ["Infinity Gauntlet"],
@@ -214,6 +302,10 @@ export const scenarios = [
         name: "The Hood - Making Connections",
         pack: "The Hood",
         img: "images/scenarios/MC24en_4A.png",
+        starRating: {
+            solo: 5,
+            multiplayer: 6
+        },
         decks: [
             {
                 name: "The Hood",
@@ -229,6 +321,10 @@ export const scenarios = [
         name: "Sandman",
         pack: "Sinister Motives",
         img: "images/scenarios/sandman.png",
+        starRating: {
+            solo: 5,
+            multiplayer: 1
+        },
         decks: [
             {
                 requiredModules: ["City in Chaos"],
@@ -239,6 +335,10 @@ export const scenarios = [
         name: "Venom",
         pack: "Sinister Motives",
         img: "images/scenarios/venom.png",
+        starRating: {
+            solo: 10,
+            multiplayer: 3
+        },
         decks: [
             {
                 requiredModules: ["Symbiotic Strength"],
@@ -249,6 +349,10 @@ export const scenarios = [
         name: "Mysterio",
         pack: "Sinister Motives",
         img: "images/scenarios/mysterio.png",
+        starRating: {
+            solo: 2,
+            multiplayer: 0
+        },
         decks: [
             {
                 requiredModules: ["Personal Nightmare"],
@@ -259,6 +363,10 @@ export const scenarios = [
         name: "The Sinister Six",
         pack: "Sinister Motives",
         img: "images/scenarios/sinister-six.png",
+        starRating: {
+            solo: 9,
+            multiplayer: 5
+        },
         decks: [
             {
                 minModules: 0,
@@ -270,6 +378,10 @@ export const scenarios = [
         name: "Venom Goblin",
         pack: "Sinister Motives",
         img: "images/scenarios/venom-goblin.png",
+        starRating: {
+            solo: 16,
+            multiplayer: 21
+        },
         decks: [
             {
                 requiredModules: ["Symbiotic Strength"],
@@ -280,6 +392,10 @@ export const scenarios = [
         name: "Sabretooth",
         pack: "Mutant Genesis",
         img: "images/scenarios/mc32_sabretooth.png",
+        starRating: {
+            solo: 8,
+            multiplayer: 10
+        },
         decks: [
             {
                 minModules: 2,
@@ -290,6 +406,10 @@ export const scenarios = [
         name: "Project Wideawake",
         pack: "Mutant Genesis",
         img: "images/scenarios/mc32_project_wideawake.png",
+        starRating: {
+            solo: 6,
+            multiplayer: 8
+        },
         decks: [
             {
                 requiredModules: ["Zero Tolerance"],
@@ -300,6 +420,10 @@ export const scenarios = [
         name: "Master Mold",
         pack: "Mutant Genesis",
         img: "images/scenarios/mc32_master_mold.png",
+        starRating: {
+            solo: 3,
+            multiplayer: 4
+        },
         decks: [
             {
                 name: "Into Play",
@@ -316,6 +440,10 @@ export const scenarios = [
         name: "Mansion Attack",
         pack: "Mutant Genesis",
         img: "images/scenarios/mc32_mansion_attack.png",
+        starRating: {
+            solo: 7,
+            multiplayer: 3
+        },
         decks: [
             {
                 requiredModules: ["Brotherhood"],
@@ -325,17 +453,29 @@ export const scenarios = [
     {
         name: "Magneto",
         pack: "Mutant Genesis",
-        img: "images/scenarios/mc32_magneto.png"
+        img: "images/scenarios/mc32_magneto.png",
+        starRating: {
+            solo: 18,
+            multiplayer: 23
+        },
     },
     {
         name: "Magog",
         pack: "MojoMania",
-        img: "images/scenarios/mc39_magog.png"
+        img: "images/scenarios/mc39_magog.png",
+        starRating: {
+            solo: 5,
+            multiplayer: 3
+        },
     },
     {
         name: "Spiral",
         pack: "MojoMania",
         img: "images/scenarios/mc39_spiral.png",
+        starRating: {
+            solo: 6,
+            multiplayer: 12
+        },
         decks: [
             {
                 minModules: 3,
@@ -349,6 +489,10 @@ export const scenarios = [
         name: "Mojo",
         pack: "MojoMania",
         img: "images/scenarios/mc39_mojo.png",
+        starRating: {
+            solo: 7,
+            multiplayer: 10
+        },
         decks: [
             {
                 minModules: 0,
@@ -367,6 +511,10 @@ export const scenarios = [
         name: "Morlock Siege",
         pack: "NeXt Evolution",
         img: "images/scenarios/morlock-siege.jpg",
+        starRating: {
+            solo: -3,
+            multiplayer: -5
+        },
         decks: [
             {
                 name: "Villains",
@@ -383,6 +531,10 @@ export const scenarios = [
         name: "On The Run",
         pack: "NeXt Evolution",
         img: "images/scenarios/on-the-run.jpg",
+        starRating: {
+            solo: 15,
+            multiplayer: 8
+        },
         decks: [
             {
                 name: "Villains",
@@ -400,6 +552,10 @@ export const scenarios = [
         name: "Juggernaut",
         pack: "NeXt Evolution",
         img: "images/scenarios/juggernaut.jpg",
+        starRating: {
+            solo: 12,
+            multiplayer: 12
+        },
         decks: [
             {
                 requiredModules: ["Hope Summers"]
@@ -410,9 +566,13 @@ export const scenarios = [
         name: "Mister Sinister",
         pack: "NeXt Evolution",
         img: "images/scenarios/mister-sinister.jpg",
+        starRating: {
+            solo: 2,
+            multiplayer: 9
+        },
         decks: [
             {
-                requiredModules:  ["Flight", "Super Strength", "Telepathy", "Hope Summers"]
+                requiredModules: ["Flight", "Super Strength", "Telepathy", "Hope Summers"]
             }
         ]
     },
@@ -420,6 +580,10 @@ export const scenarios = [
         name: "Stryfe",
         pack: "NeXt Evolution",
         img: "images/scenarios/stryfe.jpg",
+        starRating: {
+            solo: 13,
+            multiplayer: 14
+        },
         decks: [
             {
                 minModules: 2,
@@ -431,6 +595,10 @@ export const scenarios = [
         name: "Unus",
         pack: "Age of Apocalypse",
         img: "images/scenarios/unus.jpg",
+        starRating: {
+            solo: 1,
+            multiplayer: -2
+        },
         decks: [
             {
                 requiredModules: ["Infinites"]
@@ -441,6 +609,10 @@ export const scenarios = [
         name: "Four Horsemen",
         pack: "Age of Apocalypse",
         img: "images/scenarios/four-horsemen.jpg",
+        starRating: {
+            solo: 11,
+            multiplayer: 7
+        },
         decks: [
             {
                 minModules: 2
@@ -451,6 +623,10 @@ export const scenarios = [
         name: "Apocalypse",
         pack: "Age of Apocalypse",
         img: "images/scenarios/apocalypse.jpg",
+        starRating: {
+            solo: 12,
+            multiplayer: 4
+        },
         decks: [
             {
                 requiredModules: ["Prelates"],
@@ -462,6 +638,10 @@ export const scenarios = [
         name: "Dark Beast",
         pack: "Age of Apocalypse",
         img: "images/scenarios/dark-beast.jpg",
+        starRating: {
+            solo: 8,
+            multiplayer: 11
+        },
         decks: [
             {
                 requiredModules: ["Blue Moon", "Genosha", "Savage Land"]
@@ -472,6 +652,10 @@ export const scenarios = [
         name: "En Sabah Nur",
         pack: "Age of Apocalypse",
         img: "images/scenarios/en-sabah-nur.jpg",
+        starRating: {
+            solo: 9,
+            multiplayer: 8
+        },
         decks: [
             {
                 minModules: 2
@@ -482,6 +666,10 @@ export const scenarios = [
         name: "Black Widow",
         pack: "Agents of S.H.I.E.L.D.",
         img: "images/scenarios/black-widow.jpg",
+        starRating: {
+            solo: 13,
+            multiplayer: 8
+        },
         decks: [
             {
                 minModules: 2
@@ -492,6 +680,10 @@ export const scenarios = [
         name: "Batroc",
         pack: "Agents of S.H.I.E.L.D.",
         img: "images/scenarios/batroc.jpg",
+        starRating: {
+            solo: 8,
+            multiplayer: 4
+        },
         decks: [
             {
                 minModules: 2
@@ -501,12 +693,20 @@ export const scenarios = [
     {
         name: "M.O.D.O.K.",
         pack: "Agents of S.H.I.E.L.D.",
-        img: "images/scenarios/modok.jpg"
+        img: "images/scenarios/modok.jpg",
+        starRating: {
+            solo: -4,
+            multiplayer: 4
+        },
     },
     {
         name: "Thunderbolts",
         pack: "Agents of S.H.I.E.L.D.",
         img: "images/scenarios/thunderbolts.jpg",
+        starRating: {
+            solo: 3,
+            multiplayer: 11 
+        },
         decks: [
             {
                 minModules: 1,
@@ -521,6 +721,10 @@ export const scenarios = [
         name: "Baron Zemo",
         pack: "Agents of S.H.I.E.L.D.",
         img: "images/scenarios/baron-zemo.jpg",
+        starRating: {
+            solo: 22,
+            multiplayer: 7
+        },
         decks: [
             {
                 requiredModules: ["S.H.I.E.L.D. Executive Board", "Executive Board Evidence"],

--- a/src/data/starRatingDifficultyRange.js
+++ b/src/data/starRatingDifficultyRange.js
@@ -1,0 +1,8 @@
+export const starRatingDifficultyRange = {
+    0: [-7, -4],
+    1: [-3, 3],
+    2: [4, 9],
+    3: [10, 15],
+    4: [16, 22],
+    5: [23, Number.POSITIVE_INFINITY],
+  };

--- a/src/randomizer.js
+++ b/src/randomizer.js
@@ -1,9 +1,51 @@
 import {shuffleArray} from "@/helpers";
+import { starRatingDifficultyRange } from "@/data/starRatingDifficultyRange.js";
 
 export default class Randomizer {
-    randomizeScenario(scenarios, availableModules, defaultDifficulties, {additionalModules = 0, limitToScenarios: limitToScenarios = "" } = { additionalModules: 0}, playerCount = 1){
-        const availableScenarios = limitToScenarios.length > 0 ? limitToScenarios : scenarios;
+    randomizeScenario(scenarios, availableModules, defaultDifficulties, {additionalModules = 0, limitToScenarios: limitToScenarios = "", useStarRating = false, starRatingRange = starRatingDifficultyRange[2] } = { additionalModules: 0 }, playerCount = 1) {
+        let availableScenarios = limitToScenarios.length > 0 ? limitToScenarios : scenarios;
+        let starDifficultyFailure = false;
+        if (useStarRating) {
+            //Limit available scenarios to those that can be made to fall into range of starRatingRange
+            const starRatingFilteredScenarios = availableScenarios.filter(scenario => {
+                let unusedModules = [...availableModules];
+                unusedModules.sort((a, b) => a.starRating - b.starRating);
+                let scenarioStarRating = playerCount == 1 ? scenario.starRating.solo : scenario.starRating.multiplayer;
+                let nonReqModuleCount = additionalModules;
+                if (scenario.decks) {
+                    // Add all required Modules to the Scenario Star Rating
+                    scenario.decks.forEach(deck => {
+                        if (deck.requiredModules) {
+                            deck.requiredModules.forEach(moduleName => {
+                                let mi = unusedModules.findIndex(m => m.name === moduleName);
+                                if (mi > -1) {
+                                    scenarioStarRating += unusedModules[mi].starRating;
+                                    unusedModules.splice(mi, 1);
+                                }
+                            });
+                        }
+                        nonReqModuleCount += deck.minModules == undefined ? 1 : deck.minModules;
+                    });
+                } else {
+                    nonReqModuleCount += 1;
+                }
+                // Determine the min and max possible star rating based on the total number of modules
+                const scenarioRatingRange = [
+                    scenarioStarRating + unusedModules.reduce((sum, mod, index) => sum + (index < nonReqModuleCount ? mod.starRating : 0), 0),
+                    scenarioStarRating + unusedModules.reduce((sum, mod, index) => sum + (unusedModules.length - 1 - index < nonReqModuleCount ? mod.starRating : 0), 0)
+                ];
+                
+                return scenarioRatingRange[0] <= starRatingRange[1] && starRatingRange[0] <= scenarioRatingRange[1]
+            })
+            if(starRatingFilteredScenarios.length > 0) {
+                availableScenarios = starRatingFilteredScenarios;
+            } else {
+                starDifficultyFailure = true;
+            }
+        }
+
         const scenario = shuffleArray(availableScenarios).shift();
+        let currentStarDifficulty = playerCount == 1 ? scenario.starRating.solo : scenario.starRating.multiplayer;
         const encounterDecks = scenario?.decks || [{}];
 
         encounterDecks[0].name = encounterDecks[0].name || "encounter deck";
@@ -17,6 +59,7 @@ export default class Randomizer {
                         return modToTest.name === module;
                     });
                     if(modObject){
+                        currentStarDifficulty += modObject.starRating;
                         shuffledModules.splice(shuffledModules.indexOf(modObject), 1);
                         return {...modObject, required: true};
                     }
@@ -49,11 +92,29 @@ export default class Randomizer {
                 }
 
                 // Module needs to be from a specific type (e.g. Thunderbolts modules)
-                if(deck?.moduleRequirements?.type && (currentModule.types || []).indexOf(deck?.moduleRequirements?.type) < 0){
+                if (deck?.moduleRequirements?.type && (currentModule.types || []).indexOf(deck?.moduleRequirements?.type) < 0) {
                     unselectedModules.push(currentModule);
                     continue;
                 }
 
+                // Module can't modify the difficulty beyond the remaining modules ability to correct the star difficulty
+                if(useStarRating && !starDifficultyFailure) {
+                    // Make sure at least 1 remaining module can put us into the target range.
+                    const tempStarDifficulty = currentModule.starRating + currentStarDifficulty;
+                    const sortedModules = [...shuffledModules]
+                    sortedModules.sort((a, b) => a.starRating - b.starRating);
+                    const remainingModuleCount = numberOfModules - selectedModules.length - 1;
+                    const remainingModuleRatingRange = [
+                        tempStarDifficulty + sortedModules.reduce((sum, mod, index) => sum + (index < remainingModuleCount ? mod.starRating : 0), 0),
+                        tempStarDifficulty + sortedModules.reduce((sum, mod, index) => sum + (sortedModules.length - 1 - index < remainingModuleCount ? mod.starRating : 0), 0)
+                    ];
+
+                    if(!(remainingModuleRatingRange[0] <= starRatingRange[1] && starRatingRange[0] <= remainingModuleRatingRange[1])) {
+                        continue;
+                    }
+                    
+                }
+                currentStarDifficulty += currentModule.starRating;
                 selectedModules.push(currentModule);
             }
 
@@ -70,11 +131,13 @@ export default class Randomizer {
 
         const difficulties =  scenarioDifficulties.length? scenarioDifficulties:defaultDifficulties;
         const difficulty = difficulties[Math.floor(Math.random() * difficulties.length)] || "No difficulty available";
-
+        const starRatingDifficulty = starDifficultyFailure ? "Not available for selected Modules & Scenarios" : currentStarDifficulty
         return {
             scenario,
             modules,
             difficulty,
+            useStarRating,
+            starRatingDifficulty,
         };
     }
 


### PR DESCRIPTION
Based on the rankings from https://boardgamegeek.com/thread/2438111/star-difficulty-levels/page/1 

This adds a new randomization option to allow the generation of scenario decks limited by star ranking.

If a scenario can't be found that can be generated for the specified star ranking; the star ranking limit will be temporarily removed so a deck can still be generated.

Let me know what you think, or if there are any improvements you think can be made!